### PR TITLE
Added support for .props files and PackageVersions

### DIFF
--- a/src/DotNetSortRefs/Sort.xsl
+++ b/src/DotNetSortRefs/Sort.xsl
@@ -11,7 +11,7 @@
         </xsl:copy>
     </xsl:template>
 
-    <xsl:template match="ItemGroup[PackageReference|Reference]">
+    <xsl:template match="ItemGroup[PackageReference|Reference|PackageVersion]">
         <xsl:copy>
             <xsl:apply-templates select="@*|node()">
                 <xsl:sort select="translate(@Include, $uppercase, $lowercase)" data-type="text" order="ascending"/>


### PR DESCRIPTION
Add support for sorting `PackageVersion` elements in .props files. Useful for projects that use [Central Package Management ](https://devblogs.microsoft.com/nuget/introducing-central-package-management/)