### PR TITLE
.NET 7 compatibility

### DIFF
--- a/src/DotNetSortRefs/DotNetSortRefs.csproj
+++ b/src/DotNetSortRefs/DotNetSortRefs.csproj
@@ -4,7 +4,7 @@
     <VersionPrefix>1.0.1</VersionPrefix>
     <Authors>Babu Annamalai</Authors>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <AssemblyName>dotnet-sort-refs</AssemblyName>
     <PackageId>dotnet-sort-refs</PackageId>
     <PackageOutputPath>./nupkg</PackageOutputPath>

--- a/src/DotNetSortRefs/DotNetSortRefs.csproj
+++ b/src/DotNetSortRefs/DotNetSortRefs.csproj
@@ -18,8 +18,8 @@
     <EmbeddedResource Include="Sort.xsl" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
-    <PackageReference Include="System.IO.Abstractions" Version="13.2.47" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="19.2.69" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This commit just to app the .NET 7 framework to use it without needing to install a .NET 6 runtime.

I also took the opportunity to update dependencies while maintaining the compatibility with .NET 5 / .NET Core 3.1